### PR TITLE
SAMOA-21: Fix dev subscriptions email addresses

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,8 +88,8 @@ Keynote Talk at <a href="http://www.ramss.ws/2013/program/">RAMSS '13</a>: 2nd I
 
 <h2>Development related discussions:
 <a href="mailto:dev@samoa.incubator.apache.org">dev@samoa.incubator.apache.org</a>.
-<br/>You can subscribe to this list by sending an email to <br/><a href="mailto:dev-subscribe@storm.apache.org">dev-subscribe@storm.apache.org</a>.
-<br/>Likewise, you can cancel a subscription by sending an email to <br/><a href="mailto:dev-unsubscribe@storm.apache.org">dev-unsubscribe@storm.apache.org</a>.
+<br/>You can subscribe to this list by sending an email to <br/><a href="mailto:dev-subscribe@samoa.incubator.apache.org">dev-subscribe@samoa.incubator.apache.org</a>.
+<br/>Likewise, you can cancel a subscription by sending an email to <br/><a href="mailto:dev-unsubscribe@samoa.incubator.apache.org">dev-unsubscribe@samoa.incubator.apache.org</a>.
 <br/>You can view the archives of the mailing list <a href="http://mail-archives.apache.org/mod_mbox/incubator-samoa-dev">here</a>.</h2>
 
 <h2>At the current stage most of the discussion happens on the dev@ mailing list.</h2>


### PR DESCRIPTION
Change from `storm` to `incubator.samoa` in the mailing addresses. Fixes SAMOA-21