### PR TITLE
SAMOA-27: Storm upgrade to the latest stable version (0.9.4)

### DIFF
--- a/bin/samoa
+++ b/bin/samoa
@@ -201,7 +201,7 @@ elif [ $PLATFORM = 'STORM' ]; then
 	if [ "$MODE_ARG" = "cluster" ]; then
 		$STORM_EXEC jar $DEPLOYABLE com.yahoo.labs.samoa.topology.impl.StormDoTask $COMPLETE_ARG $NUM_WORKER $MODE_ARG
 	elif [ "$MODE_ARG" = "local" ]; then
-		STORM_JAR=$(ls $STORM_HOME/storm-*.jar)
+		STORM_JAR=$(ls $STORM_HOME/lib/storm-*.jar)
 		CLASSPATH="$CLASSPATH:$STORM_HOME/lib/*:$STORM_JAR:$DEPLOYABLE"
 		java -cp $CLASSPATH com.yahoo.labs.samoa.LocalStormDoTask $COMPLETE_ARG $NUM_WORKER
 	fi

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         <jmockit.version>1.13</jmockit.version>
         <junit.version>4.10</junit.version>
         <kafka.version>0.8.1</kafka.version>
-        <kryo.version>2.17</kryo.version>
+        <kryo.version>2.21</kryo.version>
         <metrics-core.version>2.2.0</metrics-core.version>
         <miniball.version>1.0.3</miniball.version>
         <s4.version>0.6.0-incubating</s4.version>
@@ -133,9 +133,9 @@
         <slf4j-log4j12.version>1.7.2</slf4j-log4j12.version>
         <slf4j-simple.version>1.7.5</slf4j-simple.version>
         <maven-surefire-plugin.version>2.18</maven-surefire-plugin.version>
-        <storm.version>0.8.2</storm.version>
+        <storm.version>0.9.4</storm.version>
         <!-- storm 0.8.2 loads zookeeper classes with hardcoded names from 3.3 version-->
-        <zookeeper.storm.version>3.3.6</zookeeper.storm.version>
+        <zookeeper.storm.version>3.4.6</zookeeper.storm.version>
     </properties>
 
     <dependencies>

--- a/samoa-storm/pom.xml
+++ b/samoa-storm/pom.xml
@@ -59,8 +59,8 @@
     </dependency>
 
     <dependency>
-      <groupId>storm</groupId>
-      <artifactId>storm</artifactId>
+      <groupId>org.apache.storm</groupId>
+      <artifactId>storm-core</artifactId>
       <version>${storm.version}</version>
       <scope>provided</scope>
     </dependency>

--- a/samoa-storm/src/main/java/com/yahoo/labs/samoa/topology/impl/StormTopologySubmitter.java
+++ b/samoa-storm/src/main/java/com/yahoo/labs/samoa/topology/impl/StormTopologySubmitter.java
@@ -102,9 +102,7 @@ public class StormTopologySubmitter {
     Config config = new Config();
     config.putAll(Utils.readStormConfig());
 
-    String nimbusHost = (String) config.get(Config.NIMBUS_HOST);
-
-    NimbusClient nc = new NimbusClient(nimbusHost);
+    NimbusClient nc = NimbusClient.getConfiguredClient(config);
     String topologyName = stormTopo.getTopologyName();
     try {
       System.out.println("Submitting topology with name: "


### PR DESCRIPTION
Storm, and consequently Zookeeper and Kryo, have been updated.
Samoa-storm compiles and passes the tests; the example of CoverType dataset (classified with the bagging algorithm) runs without problems.
Also the code of my fork with a word2vec implementation runs correctly.
