### PR TITLE
SAMOA-36: Update Apache Flink Adapter to 0.9 stable release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
         <miniball.version>1.0.3</miniball.version>
         <s4.version>0.6.0-incubating</s4.version>
         <samza.version>0.7.0</samza.version>
-        <flink.version>0.9.0-milestone-1</flink.version>
+        <flink.version>0.9.0</flink.version>
         <slf4j-log4j12.version>1.7.2</slf4j-log4j12.version>
         <slf4j-simple.version>1.7.5</slf4j-simple.version>
         <maven-surefire-plugin.version>2.18</maven-surefire-plugin.version>

--- a/samoa-flink/pom.xml
+++ b/samoa-flink/pom.xml
@@ -1,15 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   #%L
   SAMOA
   %%
-  Copyright (C) 2013 Yahoo! Inc.
+  Copyright (C) 2014 - 2015 Apache Software Foundation
   %%
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
-
+  
        http://www.apache.org/licenses/LICENSE-2.0
-
+  
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.


### PR DESCRIPTION
This patch upgrades the Flink adapter to `0.9.0` stable release. It includes several bug fixes and performance improvements along with compatibility with the new operator interfaces of Flink. 

I got a x3 speedup on VHT compared to the previous version using a local cluster with 8 cores.