### PR TITLE
SAMOA-29: Remove hardcoded value for the duration of Storm local topology execution

### DIFF
--- a/bin/samoa
+++ b/bin/samoa
@@ -201,7 +201,7 @@ elif [ $PLATFORM = 'STORM' ]; then
 	if [ "$MODE_ARG" = "cluster" ]; then
 		$STORM_EXEC jar $DEPLOYABLE org.apache.samoa.topology.impl.StormDoTask $COMPLETE_ARG $NUM_WORKER $MODE_ARG
 	elif [ "$MODE_ARG" = "local" ]; then
-		CLASSPATH="$CLASSPATH:$STORM_HOME/lib/*:$DEPLOYABLE"
+		CLASSPATH="$CLASSPATH:$STORM_HOME/lib/*:$BASE_DIR/:$DEPLOYABLE"
 		java -cp $CLASSPATH org.apache.samoa.LocalStormDoTask $COMPLETE_ARG $NUM_WORKER
 	fi
 

--- a/bin/samoa-storm.properties
+++ b/bin/samoa-storm.properties
@@ -33,3 +33,5 @@ samoa.storm.mode=local
 # possible values: any integer greater than 0  
 samoa.storm.numworker=4
 
+# samoa.storm.local.mode.execution.duration corresponds to the execution duration of the local topology  in seconds. 
+samoa.storm.local.mode.execution.duration=100

--- a/bin/samoa-storm.properties
+++ b/bin/samoa-storm.properties
@@ -34,4 +34,4 @@ samoa.storm.mode=local
 samoa.storm.numworker=4
 
 # samoa.storm.local.mode.execution.duration corresponds to the execution duration of the local topology  in seconds. 
-samoa.storm.local.mode.execution.duration=100
+samoa.storm.local.mode.execution.duration=200

--- a/samoa-storm/pom.xml
+++ b/samoa-storm/pom.xml
@@ -121,5 +121,13 @@
         </configuration>
       </plugin>
     </plugins>
+    <resources>
+      <resource>
+	<directory>${project.basedir}/../bin</directory>
+	<includes>
+	<include>*storm.properties</include>
+	</includes>
+      </resource>
+   </resources>
   </build>
 </project>

--- a/samoa-storm/pom.xml
+++ b/samoa-storm/pom.xml
@@ -121,13 +121,13 @@
         </configuration>
       </plugin>
     </plugins>
-    <resources>
-      <resource>
+   <testResources>
+      <testResource>
 	<directory>${project.basedir}/../bin</directory>
 	<includes>
 	<include>*storm.properties</include>
 	</includes>
-      </resource>
-   </resources>
+      </testResource>
+   </testResources>
   </build>
 </project>

--- a/samoa-storm/src/main/java/org/apache/samoa/LocalStormDoTask.java
+++ b/samoa-storm/src/main/java/org/apache/samoa/LocalStormDoTask.java
@@ -27,6 +27,7 @@ import org.apache.samoa.topology.impl.StormSamoaUtils;
 import org.apache.samoa.topology.impl.StormTopology;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.apache.commons.configuration.Configuration;
 
 import backtype.storm.Config;
 import backtype.storm.utils.Utils;
@@ -40,6 +41,8 @@ import backtype.storm.utils.Utils;
 public class LocalStormDoTask {
 
   private static final Logger logger = LoggerFactory.getLogger(LocalStormDoTask.class);
+  private static final String EXECUTION_DURATION_KEY ="samoa.storm.local.mode.execution.duration";
+  private static final String SAMOA_STORM_PROPERTY_FILE_LOC ="samoa-storm.properties";
 
   /**
    * The main method.
@@ -69,7 +72,10 @@ public class LocalStormDoTask {
     backtype.storm.LocalCluster cluster = new backtype.storm.LocalCluster();
     cluster.submitTopology(topologyName, conf, stormTopo.getStormBuilder().createTopology());
 
-    backtype.storm.utils.Utils.sleep(600 * 1000);
+    // Read local mode execution duration from property file
+    Configuration stormConfig = StormSamoaUtils.getPropertyConfig(LocalStormDoTask.SAMOA_STORM_PROPERTY_FILE_LOC);
+    long executionDuration= stormConfig.getLong(LocalStormDoTask.EXECUTION_DURATION_KEY);
+    backtype.storm.utils.Utils.sleep(executionDuration * 1000);
 
     cluster.killTopology(topologyName);
     cluster.shutdown();

--- a/samoa-storm/src/main/java/org/apache/samoa/LocalStormDoTask.java
+++ b/samoa-storm/src/main/java/org/apache/samoa/LocalStormDoTask.java
@@ -43,7 +43,6 @@ public class LocalStormDoTask {
   private static final Logger logger = LoggerFactory.getLogger(LocalStormDoTask.class);
   private static final String EXECUTION_DURATION_KEY ="samoa.storm.local.mode.execution.duration";
   private static final String SAMOA_STORM_PROPERTY_FILE_LOC ="samoa-storm.properties";
-
   /**
    * The main method.
    * 

--- a/samoa-storm/src/main/java/org/apache/samoa/topology/impl/StormSamoaUtils.java
+++ b/samoa-storm/src/main/java/org/apache/samoa/topology/impl/StormSamoaUtils.java
@@ -33,6 +33,10 @@ import org.apache.samoa.tasks.Task;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration.PropertiesConfiguration;
+
 /**
  * Utility class for samoa-storm project. It is used by StormDoTask to process its arguments.
  * 
@@ -106,4 +110,21 @@ public class StormSamoaUtils {
     }
     return task;
   }
+
+ public static Configuration getPropertyConfig(String configPropertyPath){
+     Configuration config = null;
+	try {
+	config = new PropertiesConfiguration(configPropertyPath);
+	  if (null == config || config.isEmpty()) {
+	     logger.error("Configuration is null or empty at file  = {}",configPropertyPath);
+	     throw new RuntimeException("Configuration is null or empty : " + configPropertyPath);       	    
+	     }
+	}
+	catch(ConfigurationException configurationException)
+	{
+	     logger.error("ConfigurationException while reading property file = {}",configurationException);
+	     throw new RuntimeException("ConfigurationException while reading property file : " + configPropertyPath);
+	}
+	return config;
+	}
 }


### PR DESCRIPTION
This fix is for SAMOA-29. Instead of the hard-coded value, the PropertiesConfiguration class of Apache commons-configuration is used to dynamically read samoa.storm.local.mode.execution.duration from config file. Other properties excluding local topology execution is left as such. A new method is added in StormSamoaUtils which can be reused to fetch other properties.