### PR TITLE
SAMOA-48: Multiple copies of evaluation statistics printed in ensemble methods

### DIFF
--- a/samoa-api/src/main/java/org/apache/samoa/learners/InstanceContent.java
+++ b/samoa-api/src/main/java/org/apache/samoa/learners/InstanceContent.java
@@ -24,31 +24,35 @@ package org.apache.samoa.learners;
  * License
  */
 
-import org.apache.samoa.core.ContentEvent;
+import net.jcip.annotations.Immutable;
 import org.apache.samoa.core.SerializableInstance;
 import org.apache.samoa.instances.Instance;
 
-import net.jcip.annotations.Immutable;
+import java.io.Serializable;
 
 /**
- * The Class InstanceContentEvent.
+ * The Class InstanceContent.
  */
 @Immutable
-final public class InstanceContentEvent implements ContentEvent {
+final public class InstanceContent implements Serializable {
 
-  /**
-	 * 
-	 */
-  private static final long serialVersionUID = -8620668863064613845L;
-  private InstanceContent instanceContent;
+  private static final long serialVersionUID = -8620668863064613841L;
 
-  public InstanceContentEvent() {
+  private long instanceIndex;
+  private int classifierIndex;
+  private int evaluationIndex;
+  private SerializableInstance instance;
+  private boolean isTraining;
+  private boolean isTesting;
+  private boolean isLast = false;
+
+  public InstanceContent() {
 
   }
 
   /**
    * Instantiates a new instance event.
-   * 
+   *
    * @param index
    *          the index
    * @param instance
@@ -56,9 +60,14 @@ final public class InstanceContentEvent implements ContentEvent {
    * @param isTraining
    *          the is training
    */
-  public InstanceContentEvent(long index, Instance instance,
-      boolean isTraining, boolean isTesting) {
-    this.instanceContent = new InstanceContent(index, instance, isTraining, isTesting);
+  public InstanceContent(long index, Instance instance,
+                         boolean isTraining, boolean isTesting) {
+    if (instance != null) {
+      this.instance = new SerializableInstance(instance);
+    }
+    this.instanceIndex = index;
+    this.isTraining = isTraining;
+    this.isTesting = isTesting;
   }
 
   /**
@@ -67,7 +76,7 @@ final public class InstanceContentEvent implements ContentEvent {
    * @return the instance.
    */
   public Instance getInstance() {
-    return this.instanceContent.getInstance();
+    return instance;
   }
 
   /**
@@ -76,7 +85,7 @@ final public class InstanceContentEvent implements ContentEvent {
    * @return the index of the data vector.
    */
   public long getInstanceIndex() {
-    return this.instanceContent.getInstanceIndex();
+    return instanceIndex;
   }
 
   /**
@@ -84,7 +93,9 @@ final public class InstanceContentEvent implements ContentEvent {
    * 
    * @return the true class of the vector.
    */
-  public int getClassId() {return this.instanceContent.getClassId();
+  public int getClassId() {
+    // return classId;
+    return (int) instance.classValue();
   }
 
   /**
@@ -93,7 +104,7 @@ final public class InstanceContentEvent implements ContentEvent {
    * @return true if this is training data.
    */
   public boolean isTraining() {
-    return this.instanceContent.isTraining();
+    return isTraining;
   }
 
   /**
@@ -102,8 +113,9 @@ final public class InstanceContentEvent implements ContentEvent {
    * @param training
    *          flag.
    */
-  public void setTraining(boolean training) {this.instanceContent.setTraining(training);}
-
+  public void setTraining(boolean training) {
+    this.isTraining = training;
+  }
 
   /**
    * Checks if is testing.
@@ -111,7 +123,7 @@ final public class InstanceContentEvent implements ContentEvent {
    * @return true if this is testing data.
    */
   public boolean isTesting() {
-    return this.instanceContent.isTesting();
+    return isTesting;
   }
 
   /**
@@ -121,7 +133,7 @@ final public class InstanceContentEvent implements ContentEvent {
    *          flag.
    */
   public void setTesting(boolean testing) {
-    this.instanceContent.setTesting(testing);
+    this.isTesting = testing;
   }
 
   /**
@@ -130,7 +142,7 @@ final public class InstanceContentEvent implements ContentEvent {
    * @return the classifier index
    */
   public int getClassifierIndex() {
-    return this.instanceContent.getClassifierIndex();
+    return classifierIndex;
   }
 
   /**
@@ -140,7 +152,7 @@ final public class InstanceContentEvent implements ContentEvent {
    *          the new classifier index
    */
   public void setClassifierIndex(int classifierIndex) {
-    this.instanceContent.setClassifierIndex(classifierIndex);
+    this.classifierIndex = classifierIndex;
   }
 
   /**
@@ -149,7 +161,7 @@ final public class InstanceContentEvent implements ContentEvent {
    * @return the evaluation index
    */
   public int getEvaluationIndex() {
-    return this.instanceContent.getEvaluationIndex();
+    return evaluationIndex;
   }
 
   /**
@@ -159,48 +171,27 @@ final public class InstanceContentEvent implements ContentEvent {
    *          the new evaluation index
    */
   public void setEvaluationIndex(int evaluationIndex) {
-    this.instanceContent.setEvaluationIndex(evaluationIndex);
+    this.evaluationIndex = evaluationIndex;
   }
 
-  /*
-   * (non-Javadoc)
-   * 
-   * @see samoa.core.ContentEvent#getKey(int)
+  /**
+   * Sets the instance index.
+   *
+   * @param instanceIndex
+   *          the new evaluation index
    */
-  public String getKey(int key) {
-    if (key == 0)
-      return Long.toString(this.getEvaluationIndex());
-    else
-      return Long.toString(10000
-          * this.getEvaluationIndex()
-          + this.getClassifierIndex());
+  public void setInstanceIndex(long instanceIndex) {
+    this.instanceIndex = instanceIndex;
   }
 
-  @Override
-  public String getKey() {
-    // System.out.println("InstanceContentEvent "+Long.toString(this.instanceIndex));
-    return Long.toString(this.getClassifierIndex());
-  }
-
-  @Override
-  public void setKey(String str) {
-    this.instanceContent.setInstanceIndex(Long.parseLong(str));
-  }
-
-  @Override
   public boolean isLastEvent() {
-    return this.instanceContent.isLastEvent();
+    return isLast;
   }
 
   public void setLast(boolean isLast) {
-    this.instanceContent.setLast(isLast);
+    this.isLast = isLast;
   }
-  /**
-   * Gets the Instance Content.
-   *
-   * @return the instance content
-   */
-  public InstanceContent getInstanceContent() {
-    return instanceContent;
-  }
+
+
+
 }

--- a/samoa-api/src/main/java/org/apache/samoa/learners/InstanceContent.java
+++ b/samoa-api/src/main/java/org/apache/samoa/learners/InstanceContent.java
@@ -25,6 +25,7 @@ package org.apache.samoa.learners;
  */
 
 import net.jcip.annotations.Immutable;
+
 import org.apache.samoa.core.SerializableInstance;
 import org.apache.samoa.instances.Instance;
 
@@ -61,7 +62,7 @@ final public class InstanceContent implements Serializable {
    *          the is training
    */
   public InstanceContent(long index, Instance instance,
-                         boolean isTraining, boolean isTesting) {
+      boolean isTraining, boolean isTesting) {
     if (instance != null) {
       this.instance = new SerializableInstance(instance);
     }
@@ -192,6 +193,11 @@ final public class InstanceContent implements Serializable {
     this.isLast = isLast;
   }
 
-
-
+  @Override
+  public String toString() {
+    return String
+        .format(
+            "InstanceContent [instanceIndex=%s, classifierIndex=%s, evaluationIndex=%s, instance=%s, isTraining=%s, isTesting=%s, isLast=%s]",
+            instanceIndex, classifierIndex, evaluationIndex, instance, isTraining, isTesting, isLast);
+  }
 }

--- a/samoa-api/src/main/java/org/apache/samoa/learners/InstancesContentEvent.java
+++ b/samoa-api/src/main/java/org/apache/samoa/learners/InstancesContentEvent.java
@@ -30,10 +30,6 @@ import java.util.LinkedList;
 import java.util.List;
 
 import org.apache.samoa.core.ContentEvent;
-import org.apache.samoa.core.SerializableInstance;
-import org.apache.samoa.instances.Instance;
-
-//import weka.core.Instance;
 
 /**
  * The Class InstanceEvent.
@@ -45,49 +41,25 @@ final public class InstancesContentEvent implements ContentEvent {
 	 * 
 	 */
   private static final long serialVersionUID = -8620668863064613845L;
-  private long instanceIndex;
-  private int classifierIndex;
-  private int evaluationIndex;
-  // private SerializableInstance instance;
-  private boolean isTraining;
-  private boolean isTesting;
-  private boolean isLast = false;
+
+  protected List<InstanceContent> instanceList = new LinkedList<InstanceContent>();
 
   public InstancesContentEvent() {
 
   }
 
   /**
-   * Instantiates a new instance event.
-   * 
-   * @param index
-   *          the index
-   * @param instance
-   *          the instance
-   * @param isTraining
-   *          the is training
+   * Instantiates a new event with a list of InstanceContent.
+   *
    */
-  public InstancesContentEvent(long index,// Instance instance,
-      boolean isTraining, boolean isTesting) {
-    /*
-     * if (instance != null) { this.instance = new
-     * SerializableInstance(instance); }
-     */
-    this.instanceIndex = index;
-    this.isTraining = isTraining;
-    this.isTesting = isTesting;
-  }
 
   public InstancesContentEvent(InstanceContentEvent event) {
-    this.instanceIndex = event.getInstanceIndex();
-    this.isTraining = event.isTraining();
-    this.isTesting = event.isTesting();
+    this.add(event.getInstanceContent());
   }
 
-  protected List<Instance> instanceList = new LinkedList<Instance>();
 
-  public void add(Instance instance) {
-    instanceList.add(new SerializableInstance(instance));
+  public void add(InstanceContent instance) {
+    instanceList.add(instance);
   }
 
   /**
@@ -95,74 +67,29 @@ final public class InstancesContentEvent implements ContentEvent {
    * 
    * @return the instance.
    */
-  public Instance[] getInstances() {
-    return instanceList.toArray(new Instance[instanceList.size()]);
+  public InstanceContent[] getInstances() {
+    return instanceList.toArray(new InstanceContent[instanceList.size()]);
   }
 
-  /**
-   * Gets the instance index.
-   * 
-   * @return the index of the data vector.
-   */
-  public long getInstanceIndex() {
-    return instanceIndex;
-  }
-
-  /**
-   * Checks if is training.
-   * 
-   * @return true if this is training data.
-   */
-  public boolean isTraining() {
-    return isTraining;
-  }
-
-  /**
-   * Checks if is testing.
-   * 
-   * @return true if this is testing data.
-   */
-  public boolean isTesting() {
-    return isTesting;
-  }
 
   /**
    * Gets the classifier index.
-   * 
+   *
    * @return the classifier index
    */
   public int getClassifierIndex() {
-    return classifierIndex;
-  }
-
-  /**
-   * Sets the classifier index.
-   * 
-   * @param classifierIndex
-   *          the new classifier index
-   */
-  public void setClassifierIndex(int classifierIndex) {
-    this.classifierIndex = classifierIndex;
+    return this.instanceList.get(0).getClassifierIndex();
   }
 
   /**
    * Gets the evaluation index.
-   * 
+   *
    * @return the evaluation index
    */
   public int getEvaluationIndex() {
-    return evaluationIndex;
+    return this.instanceList.get(0).getEvaluationIndex();
   }
 
-  /**
-   * Sets the evaluation index.
-   * 
-   * @param evaluationIndex
-   *          the new evaluation index
-   */
-  public void setEvaluationIndex(int evaluationIndex) {
-    this.evaluationIndex = evaluationIndex;
-  }
 
   /*
    * (non-Javadoc)
@@ -185,17 +112,16 @@ final public class InstancesContentEvent implements ContentEvent {
   }
 
   @Override
-  public void setKey(String str) {
-    this.instanceIndex = Long.parseLong(str);
+  public void setKey(String key) {
+    //No needed
   }
 
   @Override
   public boolean isLastEvent() {
-    return isLast;
+    return this.instanceList.get(this.instanceList.size()-1).isLastEvent();
   }
 
-  public void setLast(boolean isLast) {
-    this.isLast = isLast;
+  public List<InstanceContent> getList() {
+    return this.instanceList;
   }
-
 }

--- a/samoa-api/src/main/java/org/apache/samoa/learners/classifiers/ensemble/PredictionCombinerProcessor.java
+++ b/samoa-api/src/main/java/org/apache/samoa/learners/classifiers/ensemble/PredictionCombinerProcessor.java
@@ -106,14 +106,13 @@ public class PredictionCombinerProcessor implements Processor {
 
     addStatisticsForInstanceReceived(instanceIndex, inEvent.getClassifierIndex(), prediction, 1);
 
-    if (inEvent.isLastEvent() || hasAllVotesArrivedInstance(instanceIndex)) {
+    if (hasAllVotesArrivedInstance(instanceIndex)) {
       DoubleVector combinedVote = this.mapVotesforInstanceReceived.get(instanceIndex);
       if (combinedVote == null) {
         combinedVote = new DoubleVector(new double[inEvent.getInstance().numClasses()]);
       }
-      ResultContentEvent outContentEvent = new ResultContentEvent(inEvent.getInstanceIndex(),
-          inEvent.getInstance(), inEvent.getClassId(),
-          combinedVote.getArrayCopy(), inEvent.isLastEvent());
+      ResultContentEvent outContentEvent = new ResultContentEvent(inEvent.getInstanceIndex(), inEvent.getInstance(),
+          inEvent.getClassId(), combinedVote.getArrayCopy(), inEvent.isLastEvent());
       outContentEvent.setEvaluationIndex(inEvent.getEvaluationIndex());
       outputStream.put(outContentEvent);
       clearStatisticsInstance(instanceIndex);
@@ -133,7 +132,6 @@ public class PredictionCombinerProcessor implements Processor {
 
   /*
    * (non-Javadoc)
-   * 
    * @see samoa.core.Processor#newProcessor(samoa.core.Processor)
    */
   @Override

--- a/samoa-api/src/main/java/org/apache/samoa/learners/classifiers/ensemble/PredictionCombinerProcessor.java
+++ b/samoa-api/src/main/java/org/apache/samoa/learners/classifiers/ensemble/PredictionCombinerProcessor.java
@@ -105,7 +105,6 @@ public class PredictionCombinerProcessor implements Processor {
     int instanceIndex = (int) inEvent.getInstanceIndex();
 
     addStatisticsForInstanceReceived(instanceIndex, inEvent.getClassifierIndex(), prediction, 1);
-
     if (hasAllVotesArrivedInstance(instanceIndex)) {
       DoubleVector combinedVote = this.mapVotesforInstanceReceived.get(instanceIndex);
       if (combinedVote == null) {

--- a/samoa-api/src/main/java/org/apache/samoa/learners/classifiers/trees/FilterProcessor.java
+++ b/samoa-api/src/main/java/org/apache/samoa/learners/classifiers/trees/FilterProcessor.java
@@ -78,7 +78,7 @@ final class FilterProcessor implements Processor {
       this.waitingInstances++;
       if (this.waitingInstances == this.batchSize || instanceContentEvent.isLastEvent()) {
         // Send Instances
-        InstancesContentEvent outputEvent = new InstancesContentEvent(instanceContentEvent);
+        InstancesContentEvent outputEvent = new InstancesContentEvent();
         while (!this.contentEventList.isEmpty()) {
           InstanceContentEvent ice = this.contentEventList.remove(0);
           outputEvent.add(ice.getInstanceContent());

--- a/samoa-api/src/main/java/org/apache/samoa/learners/classifiers/trees/FilterProcessor.java
+++ b/samoa-api/src/main/java/org/apache/samoa/learners/classifiers/trees/FilterProcessor.java
@@ -79,16 +79,10 @@ final class FilterProcessor implements Processor {
       if (this.waitingInstances == this.batchSize || instanceContentEvent.isLastEvent()) {
         // Send Instances
         InstancesContentEvent outputEvent = new InstancesContentEvent(instanceContentEvent);
-        boolean isLastEvent = false;
         while (!this.contentEventList.isEmpty()) {
           InstanceContentEvent ice = this.contentEventList.remove(0);
-          Instance inst = ice.getInstance();
-          outputEvent.add(inst);
-          if (!isLastEvent) {
-            isLastEvent = ice.isLastEvent();
-          }
+          outputEvent.add(ice.getInstanceContent());
         }
-        outputEvent.setLast(isLastEvent);
         this.waitingInstances = 0;
         this.outputStream.put(outputEvent);
         if (this.delay > 0) {

--- a/samoa-api/src/main/java/org/apache/samoa/learners/classifiers/trees/ModelAggregatorProcessor.java
+++ b/samoa-api/src/main/java/org/apache/samoa/learners/classifiers/trees/ModelAggregatorProcessor.java
@@ -20,6 +20,8 @@ package org.apache.samoa.learners.classifiers.trees;
  * #L%
  */
 
+import static org.apache.samoa.moa.core.Utils.maxIndex;
+
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -39,7 +41,6 @@ import org.apache.samoa.instances.Instance;
 import org.apache.samoa.instances.Instances;
 import org.apache.samoa.instances.InstancesHeader;
 import org.apache.samoa.learners.InstanceContent;
-import org.apache.samoa.learners.InstanceContentEvent;
 import org.apache.samoa.learners.InstancesContentEvent;
 import org.apache.samoa.learners.ResultContentEvent;
 import org.apache.samoa.moa.classifiers.core.AttributeSplitSuggestion;
@@ -49,8 +50,6 @@ import org.apache.samoa.moa.classifiers.core.splitcriteria.SplitCriterion;
 import org.apache.samoa.topology.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.apache.samoa.moa.core.Utils.maxIndex;
 
 /**
  * Model Aggegator Processor consists of the decision tree model. It connects to local-statistic PI via attribute stream

--- a/samoa-local/src/test/java/org/apache/samoa/AlgosTest.java
+++ b/samoa-local/src/test/java/org/apache/samoa/AlgosTest.java
@@ -27,7 +27,6 @@ public class AlgosTest {
 
   @Test
   public void testVHTLocal() throws Exception {
-
     TestParams vhtConfig = new TestParams.Builder()
         .inputInstances(200_000)
         .samplingSize(20_000)
@@ -42,7 +41,6 @@ public class AlgosTest {
         .taskClassName(LocalDoTask.class.getName())
         .build();
     TestUtils.test(vhtConfig);
-
   }
 
   @Test
@@ -50,8 +48,8 @@ public class AlgosTest {
     TestParams baggingConfig = new TestParams.Builder()
         .inputInstances(200_000)
         .samplingSize(20_000)
-        .evaluationInstances(180_000)
-        .classifiedInstances(210_000)
+        .evaluationInstances(200_000)
+        .classifiedInstances(200_000)
         .classificationsCorrect(60f)
         .kappaStat(0f)
         .kappaTempStat(0f)
@@ -61,12 +59,10 @@ public class AlgosTest {
         .taskClassName(LocalDoTask.class.getName())
         .build();
     TestUtils.test(baggingConfig);
-
   }
 
   @Test
   public void testNaiveBayesLocal() throws Exception {
-
     TestParams vhtConfig = new TestParams.Builder()
         .inputInstances(200_000)
         .samplingSize(20_000)
@@ -81,7 +77,5 @@ public class AlgosTest {
         .taskClassName(LocalDoTask.class.getName())
         .build();
     TestUtils.test(vhtConfig);
-
   }
-
 }


### PR DESCRIPTION
This fixes the multiple copies of the output.
Works fine for VHT.
For ensembles I ran into something that seems like a race condition.
Sometimes I get n votes (where n is the ensemble size) for the final instance multiple times, sometimes it doesn't even get to n votes (so it does not print).
This behavior is very weird because we are not using threads in local at all.