### PR TITLE
SAMOA-52: Fix nominal attribute problem in VHT

### DIFF
--- a/samoa-api/src/main/java/org/apache/samoa/learners/classifiers/trees/ActiveLearningNode.java
+++ b/samoa-api/src/main/java/org/apache/samoa/learners/classifiers/trees/ActiveLearningNode.java
@@ -178,6 +178,8 @@ final class ActiveLearningNode extends LearningNode {
     this.isSplitting = false;
     logger.trace("wasted instance: {}", this.thrownAwayInstance);
     this.thrownAwayInstance = 0;
+    this.bestSuggestion = null;
+    this.secondBestSuggestion = null;
   }
 
   AttributeSplitSuggestion getDistributedBestSuggestion() {

--- a/samoa-api/src/main/java/org/apache/samoa/learners/classifiers/trees/ModelAggregatorProcessor.java
+++ b/samoa-api/src/main/java/org/apache/samoa/learners/classifiers/trees/ModelAggregatorProcessor.java
@@ -439,22 +439,24 @@ final class ModelAggregatorProcessor implements Processor {
    *          The data structure to represents the filtering of the instance using the tree model.
    */
   private void attemptToSplit(ActiveLearningNode activeLearningNode, FoundNode foundNode) {
-    // Increment the split ID
-    this.splitId++;
+    if (!activeLearningNode.observedClassDistributionIsPure()) {
+      // Increment the split ID
+      this.splitId++;
 
-    // Schedule time-out thread
-    ScheduledFuture<?> timeOutHandler = this.executor.schedule(new AggregationTimeOutHandler(this.splitId,
-        this.timedOutSplittingNodes), this.timeOut, TimeUnit.SECONDS);
+      // Schedule time-out thread
+      ScheduledFuture<?> timeOutHandler = this.executor.schedule(new AggregationTimeOutHandler(this.splitId,
+              this.timedOutSplittingNodes), this.timeOut, TimeUnit.SECONDS);
 
-    // Keep track of the splitting node information, so that we can continue the
-    // split
-    // once we receive all local statistic calculation from Local Statistic PI
-    // this.splittingNodes.put(Long.valueOf(this.splitId), new
-    // SplittingNodeInfo(activeLearningNode, foundNode, null));
-    this.splittingNodes.put(this.splitId, new SplittingNodeInfo(activeLearningNode, foundNode, timeOutHandler));
+      // Keep track of the splitting node information, so that we can continue the
+      // split
+      // once we receive all local statistic calculation from Local Statistic PI
+      // this.splittingNodes.put(Long.valueOf(this.splitId), new
+      // SplittingNodeInfo(activeLearningNode, foundNode, null));
+      this.splittingNodes.put(this.splitId, new SplittingNodeInfo(activeLearningNode, foundNode, timeOutHandler));
 
-    // Inform Local Statistic PI to perform local statistic calculation
-    activeLearningNode.requestDistributedSuggestions(this.splitId, this);
+      // Inform Local Statistic PI to perform local statistic calculation
+      activeLearningNode.requestDistributedSuggestions(this.splitId, this);
+    }
   }
 
   /**


### PR DESCRIPTION
1. We don't need to split if the class distribution in a node is pure
2. We need to reset the best and second best attribute after an attempt of split. 

Every time we want to decide if we do a split, we should not reuse the best and second best split from previous attempts to split. So each time we want to decide if we split or not, we recollect the information from the attributes, and then with the best and second best split, decide using the Hoeffding bound. After that, we need to reset the best and second best split, and start again.