### PR TITLE
Patch for SAMOA-58 (Samoa AvroFileStream from HDFSFileStreamSource stops at end of first file)

### DIFF
--- a/bin/samoa
+++ b/bin/samoa
@@ -47,7 +47,7 @@ JAR_PATH=$2
 JAR_FILE=$(basename $JAR_PATH)
 JAR_DIR=$(dirname $JAR_PATH)
 OPTIONS=$3
-
+#JAVA_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005"
 
 if [ $PLATFORM = 'S4' ]; then
 
@@ -274,8 +274,11 @@ elif [ $PLATFORM = 'SAMZA' ]; then
         done
 
         DEPLOYABLE=$JAR_PATH
-        java -Dsamza.log.dir=$BASE_DIR/logs -Dsamza.container.name=client -cp $DEPLOYABLE org.apache.samoa.SamzaDoTask $COMPLETE_ARG --mode=$MODE_ARG \
-               --yarn_home=$YARN_HOME/conf --zookeeper=$ZOOKEEPER_HOST:$ZOOKEEPER_PORT --kafka=$KAFKA_BROKER_LIST \
+        #HADOOP_CLASSPATH=`hadoop classpath`
+        YARN_CLASSPATH=`yarn classpath`
+        java -Dsamza.log.dir=$BASE_DIR/logs -Dsamza.container.name=client \
+               -cp $YARN_CLASSPATH:$DEPLOYABLE org.apache.samoa.SamzaDoTask $COMPLETE_ARG \
+               --mode=$MODE_ARG --yarn_home=$YARN_HOME/conf --zookeeper=$ZOOKEEPER_HOST:$ZOOKEEPER_PORT --kafka=$KAFKA_BROKER_LIST \
                --jar_package=$JAR_PATH --yarn_am_mem=$YARN_AM_MEMORY --yarn_container_mem=$YARN_CONTAINER_MEMORY \
                --kafka_replication_factor=$KAFKA_REPLICATION_FACTOR --checkpoint_frequency=$CHECKPOINT_FREQUENCY \
                --kryo_register=$BASE_DIR/$KRYO_REGISTER_FILE --pi_per_container=$PI_PER_CONTAINER \

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
 
         <commons-lang3.version>3.1</commons-lang3.version>
         <guava.version>17.0</guava.version>
-        <hadoop.version>2.2.0</hadoop.version>
+        <hadoop.version>2.6.0</hadoop.version>
         <javacliparser.version>0.5.0</javacliparser.version>
         <jcip-annotations.version>1.0</jcip-annotations.version>
         <jmockit.version>1.13</jmockit.version>
@@ -125,7 +125,7 @@
         <kryo.version>2.21</kryo.version>
         <metrics-core.version>2.2.0</metrics-core.version>
         <miniball.version>1.0.3</miniball.version>
-        <samza.version>0.7.0</samza.version>
+        <samza.version>0.10</samza.version>
         <flink.version>0.10.1</flink.version>
         <slf4j-log4j12.version>1.7.2</slf4j-log4j12.version>
         <slf4j-simple.version>1.7.5</slf4j-simple.version>
@@ -156,10 +156,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.5</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         <kryo.version>2.21</kryo.version>
         <metrics-core.version>2.2.0</metrics-core.version>
         <miniball.version>1.0.3</miniball.version>
-        <samza.version>0.10.0</samza.version>
+        <samza.version>0.7.0</samza.version>
         <flink.version>0.10.1</flink.version>
         <slf4j-log4j12.version>1.7.2</slf4j-log4j12.version>
         <slf4j-simple.version>1.7.5</slf4j-simple.version>

--- a/pom.xml
+++ b/pom.xml
@@ -158,8 +158,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.5</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         <kryo.version>2.21</kryo.version>
         <metrics-core.version>2.2.0</metrics-core.version>
         <miniball.version>1.0.3</miniball.version>
-        <samza.version>0.10</samza.version>
+        <samza.version>0.10.0</samza.version>
         <flink.version>0.10.1</flink.version>
         <slf4j-log4j12.version>1.7.2</slf4j-log4j12.version>
         <slf4j-simple.version>1.7.5</slf4j-simple.version>

--- a/samoa-api/src/main/java/org/apache/samoa/evaluation/F1ClassificationPerformanceEvaluator.java
+++ b/samoa-api/src/main/java/org/apache/samoa/evaluation/F1ClassificationPerformanceEvaluator.java
@@ -33,7 +33,7 @@ public class F1ClassificationPerformanceEvaluator extends AbstractMOAObject impl
         ClassificationPerformanceEvaluator {
 
     private static final long serialVersionUID = 1L;
-    protected int numClasses;
+    protected int numClasses = -1;
 
     protected long[] support;
     protected long[] truePos;
@@ -63,6 +63,7 @@ public class F1ClassificationPerformanceEvaluator extends AbstractMOAObject impl
 
     @Override
     public void addResult(Instance inst, double[] classVotes) {
+        if (numClasses==-1) reset(inst.numClasses());
         int trueClass = (int) inst.classValue();
         this.support[trueClass] += 1;
         int predictedClass = Utils.maxIndex(classVotes);

--- a/samoa-api/src/main/java/org/apache/samoa/evaluation/F1ClassificationPerformanceEvaluator.java
+++ b/samoa-api/src/main/java/org/apache/samoa/evaluation/F1ClassificationPerformanceEvaluator.java
@@ -48,6 +48,7 @@ public class F1ClassificationPerformanceEvaluator extends AbstractMOAObject impl
 
     public void reset(int numClasses) {
         this.numClasses = numClasses;
+        this.support = new long[numClasses];
         this.truePos = new long[numClasses];
         this.falsePos = new long[numClasses];
         this.trueNeg = new long[numClasses];

--- a/samoa-api/src/main/java/org/apache/samoa/evaluation/F1ClassificationPerformanceEvaluator.java
+++ b/samoa-api/src/main/java/org/apache/samoa/evaluation/F1ClassificationPerformanceEvaluator.java
@@ -26,6 +26,10 @@ import org.apache.samoa.instances.Utils;
 import org.apache.samoa.moa.AbstractMOAObject;
 import org.apache.samoa.moa.core.Measurement;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Vector;
+
 /**
  * Created by Edi Bice (edi.bice gmail com) on 2/22/2016.
  */
@@ -84,7 +88,12 @@ public class F1ClassificationPerformanceEvaluator extends AbstractMOAObject impl
 
     @Override
     public Measurement[] getPerformanceMeasurements() {
-        return getF1Measurements();
+        List<Measurement> measurements = new Vector<>();
+        Collections.addAll(measurements, getSupportMeasurements());
+        Collections.addAll(measurements, getPrecisionMeasurements());
+        Collections.addAll(measurements, getRecallMeasurements());
+        Collections.addAll(measurements, getF1Measurements());
+        return measurements.toArray(new Measurement[measurements.size()]);
     }
 
     private Measurement[] getSupportMeasurements() {

--- a/samoa-api/src/main/java/org/apache/samoa/evaluation/F1ClassificationPerformanceEvaluator.java
+++ b/samoa-api/src/main/java/org/apache/samoa/evaluation/F1ClassificationPerformanceEvaluator.java
@@ -100,7 +100,7 @@ public class F1ClassificationPerformanceEvaluator extends AbstractMOAObject impl
         Measurement[] measurements = new Measurement[this.numClasses];
         for (int i = 0; i < this.numClasses; i++) {
             String ml = String.format("class %s precision", i);
-            measurements[i] = new Measurement(ml, getPrecision(i));
+            measurements[i] = new Measurement(ml, getPrecision(i), 10);
         }
         return measurements;
     }
@@ -109,7 +109,7 @@ public class F1ClassificationPerformanceEvaluator extends AbstractMOAObject impl
         Measurement[] measurements = new Measurement[this.numClasses];
         for (int i = 0; i < this.numClasses; i++) {
             String ml = String.format("class %s recall", i);
-            measurements[i] = new Measurement(ml, getRecall(i));
+            measurements[i] = new Measurement(ml, getRecall(i), 10);
         }
         return measurements;
     }
@@ -118,7 +118,7 @@ public class F1ClassificationPerformanceEvaluator extends AbstractMOAObject impl
         Measurement[] measurements = new Measurement[this.numClasses];
         for (int i = 0; i < this.numClasses; i++) {
             String ml = String.format("class %s f1-score", i);
-            measurements[i] = new Measurement(ml, getF1Score(i));
+            measurements[i] = new Measurement(ml, getF1Score(i), 10);
         }
         return measurements;
     }

--- a/samoa-api/src/main/java/org/apache/samoa/evaluation/F1ClassificationPerformanceEvaluator.java
+++ b/samoa-api/src/main/java/org/apache/samoa/evaluation/F1ClassificationPerformanceEvaluator.java
@@ -1,0 +1,146 @@
+package org.apache.samoa.evaluation;
+
+/*
+ * #%L
+ * SAMOA
+ * %%
+ * Copyright (C) 2014 - 2016 Apache Software Foundation
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+
+import org.apache.samoa.instances.Instance;
+import org.apache.samoa.instances.Utils;
+import org.apache.samoa.moa.AbstractMOAObject;
+import org.apache.samoa.moa.core.Measurement;
+
+/**
+ * Created by Edi Bice (edi.bice gmail com) on 2/22/2016.
+ */
+public class F1ClassificationPerformanceEvaluator extends AbstractMOAObject implements
+        ClassificationPerformanceEvaluator {
+
+    private static final long serialVersionUID = 1L;
+    protected int numClasses;
+
+    protected long[] support;
+    protected long[] truePos;
+    protected long[] falsePos;
+    protected long[] trueNeg;
+    protected long[] falseNeg;
+
+    @Override
+    public void reset() {
+        reset(this.numClasses);
+    }
+
+    public void reset(int numClasses) {
+        this.numClasses = numClasses;
+        this.truePos = new long[numClasses];
+        this.falsePos = new long[numClasses];
+        this.trueNeg = new long[numClasses];
+        this.falseNeg = new long[numClasses];
+        for (int i = 0; i < this.numClasses; i++) {
+            this.support[i] = 0;
+            this.truePos[i] = 0;
+            this.falsePos[i] = 0;
+            this.trueNeg[i] = 0;
+            this.falseNeg[i] = 0;
+        }
+    }
+
+    @Override
+    public void addResult(Instance inst, double[] classVotes) {
+        int trueClass = (int) inst.classValue();
+        this.support[trueClass] += 1;
+        int predictedClass = Utils.maxIndex(classVotes);
+        if (predictedClass == trueClass) {
+            this.truePos[trueClass] += 1;
+            for (int i = 0; i < this.numClasses; i++) {
+                if (i!=predictedClass) this.trueNeg[i] += 1;
+            }
+        } else {
+            this.falsePos[predictedClass] += 1;
+            this.falseNeg[trueClass] += 1;
+            for (int i = 0; i < this.numClasses; i++) {
+                if (!(i==predictedClass || i==trueClass)) this.trueNeg[i] += 1;
+            }
+        }
+    }
+
+    @Override
+    public Measurement[] getPerformanceMeasurements() {
+        return getF1Measurements();
+    }
+
+    private Measurement[] getSupportMeasurements() {
+        Measurement[] measurements = new Measurement[this.numClasses];
+        for (int i = 0; i < this.numClasses; i++) {
+            String ml = String.format("class %s support", i);
+            measurements[i] = new Measurement(ml, this.support[i]);
+        }
+        return measurements;
+    }
+
+    private Measurement[] getPrecisionMeasurements() {
+        Measurement[] measurements = new Measurement[this.numClasses];
+        for (int i = 0; i < this.numClasses; i++) {
+            String ml = String.format("class %s precision", i);
+            measurements[i] = new Measurement(ml, getPrecision(i));
+        }
+        return measurements;
+    }
+
+    private Measurement[] getRecallMeasurements() {
+        Measurement[] measurements = new Measurement[this.numClasses];
+        for (int i = 0; i < this.numClasses; i++) {
+            String ml = String.format("class %s recall", i);
+            measurements[i] = new Measurement(ml, getRecall(i));
+        }
+        return measurements;
+    }
+
+    private Measurement[] getF1Measurements() {
+        Measurement[] measurements = new Measurement[this.numClasses];
+        for (int i = 0; i < this.numClasses; i++) {
+            String ml = String.format("class %s f1-score", i);
+            measurements[i] = new Measurement(ml, getF1Score(i));
+        }
+        return measurements;
+    }
+
+    @Override
+    public void getDescription(StringBuilder sb, int indent) {
+        Measurement.getMeasurementsDescription(getSupportMeasurements(), sb, indent);
+        Measurement.getMeasurementsDescription(getPrecisionMeasurements(), sb, indent);
+        Measurement.getMeasurementsDescription(getRecallMeasurements(), sb, indent);
+        Measurement.getMeasurementsDescription(getF1Measurements(), sb, indent);
+    }
+
+    private double getPrecision(int classIndex) {
+        return (double) this.truePos[classIndex] / (this.truePos[classIndex] + this.falsePos[classIndex]);
+    }
+
+    private double getRecall(int classIndex) {
+        return (double) this.truePos[classIndex] / (this.truePos[classIndex] + this.falseNeg[classIndex]);
+    }
+
+    private double getF1Score(int classIndex) {
+        double precision = getPrecision(classIndex);
+        double recall = getRecall(classIndex);
+        return 2 * (precision * recall) / (precision + recall);
+    }
+
+}

--- a/samoa-api/src/main/java/org/apache/samoa/learners/classifiers/SingleClassifier.java
+++ b/samoa-api/src/main/java/org/apache/samoa/learners/classifiers/SingleClassifier.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import org.apache.samoa.core.Processor;
 import org.apache.samoa.instances.Instances;
 import org.apache.samoa.learners.AdaptiveLearner;
+import org.apache.samoa.learners.ClassificationLearner;
 import org.apache.samoa.learners.Learner;
 import org.apache.samoa.moa.classifiers.core.driftdetection.ChangeDetector;
 import org.apache.samoa.topology.Stream;
@@ -44,7 +45,7 @@ import com.github.javacliparser.Configurable;
  * Classifier that contain a single classifier.
  * 
  */
-public final class SingleClassifier implements Learner, AdaptiveLearner, Configurable {
+public final class SingleClassifier implements ClassificationLearner, AdaptiveLearner, Configurable {
 
   private static final long serialVersionUID = 684111382631697031L;
 

--- a/samoa-api/src/main/java/org/apache/samoa/learners/classifiers/ensemble/AdaptiveBagging.java
+++ b/samoa-api/src/main/java/org/apache/samoa/learners/classifiers/ensemble/AdaptiveBagging.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import org.apache.samoa.core.Processor;
 import org.apache.samoa.instances.Instances;
 import org.apache.samoa.learners.AdaptiveLearner;
+import org.apache.samoa.learners.ClassificationLearner;
 import org.apache.samoa.learners.Learner;
 import org.apache.samoa.learners.classifiers.trees.VerticalHoeffdingTree;
 import org.apache.samoa.moa.classifiers.core.driftdetection.ADWINChangeDetector;
@@ -47,7 +48,7 @@ import com.github.javacliparser.IntOption;
 /**
  * An adaptive version of the Bagging Classifier by Oza and Russell.
  */
-public class AdaptiveBagging implements Learner, Configurable {
+public class AdaptiveBagging implements ClassificationLearner, Configurable {
 
   private static final long serialVersionUID = 8217274236558839040L;
   private static final Logger logger = LoggerFactory.getLogger(AdaptiveBagging.class);

--- a/samoa-api/src/main/java/org/apache/samoa/learners/classifiers/ensemble/Bagging.java
+++ b/samoa-api/src/main/java/org/apache/samoa/learners/classifiers/ensemble/Bagging.java
@@ -28,6 +28,7 @@ import java.util.Set;
 
 import org.apache.samoa.core.Processor;
 import org.apache.samoa.instances.Instances;
+import org.apache.samoa.learners.ClassificationLearner;
 import org.apache.samoa.learners.Learner;
 import org.apache.samoa.learners.classifiers.trees.VerticalHoeffdingTree;
 import org.apache.samoa.topology.Stream;
@@ -43,7 +44,7 @@ import com.google.common.collect.ImmutableSet;
 /**
  * The Bagging Classifier by Oza and Russell.
  */
-public class Bagging implements Learner, Configurable {
+public class Bagging implements ClassificationLearner, Configurable {
 
   /** The Constant serialVersionUID. */
   private static final long serialVersionUID = -2971850264864952099L;

--- a/samoa-api/src/main/java/org/apache/samoa/learners/classifiers/ensemble/Boosting.java
+++ b/samoa-api/src/main/java/org/apache/samoa/learners/classifiers/ensemble/Boosting.java
@@ -30,6 +30,7 @@ import java.util.Set;
 
 import org.apache.samoa.core.Processor;
 import org.apache.samoa.instances.Instances;
+import org.apache.samoa.learners.ClassificationLearner;
 import org.apache.samoa.learners.Learner;
 import org.apache.samoa.learners.classifiers.SingleClassifier;
 import org.apache.samoa.topology.Stream;
@@ -42,7 +43,7 @@ import com.github.javacliparser.IntOption;
 /**
  * The Bagging Classifier by Oza and Russell.
  */
-public class Boosting implements Learner, Configurable {
+public class Boosting implements ClassificationLearner, Configurable {
 
   /** The Constant serialVersionUID. */
   private static final long serialVersionUID = -2971850264864952099L;

--- a/samoa-api/src/main/java/org/apache/samoa/moa/core/Measurement.java
+++ b/samoa-api/src/main/java/org/apache/samoa/moa/core/Measurement.java
@@ -36,12 +36,17 @@ public class Measurement extends AbstractMOAObject {
   private static final long serialVersionUID = 1L;
 
   protected String name;
-
   protected double value;
+  protected int fractionDigits;
 
   public Measurement(String name, double value) {
     this.name = name;
     this.value = value;
+  }
+
+  public Measurement(String name, double value, int fractionDigits) {
+    this(name, value);
+    this.fractionDigits = fractionDigits;
   }
 
   public String getName() {
@@ -110,6 +115,6 @@ public class Measurement extends AbstractMOAObject {
   public void getDescription(StringBuilder sb, int indent) {
     sb.append(getName());
     sb.append(" = ");
-    sb.append(StringUtils.doubleToString(getValue(), 3));
+    sb.append(StringUtils.doubleToString(getValue(), this.fractionDigits));
   }
 }

--- a/samoa-api/src/main/java/org/apache/samoa/moa/core/Measurement.java
+++ b/samoa-api/src/main/java/org/apache/samoa/moa/core/Measurement.java
@@ -40,12 +40,12 @@ public class Measurement extends AbstractMOAObject {
   protected int fractionDigits;
 
   public Measurement(String name, double value) {
-    this.name = name;
-    this.value = value;
+    this(name, value, 3);
   }
 
   public Measurement(String name, double value, int fractionDigits) {
-    this(name, value);
+    this.name = name;
+    this.value = value;
     this.fractionDigits = fractionDigits;
   }
 

--- a/samoa-api/src/main/java/org/apache/samoa/streams/ArffFileStream.java
+++ b/samoa-api/src/main/java/org/apache/samoa/streams/ArffFileStream.java
@@ -41,9 +41,9 @@ public class ArffFileStream extends FileStream {
   public FileOption arffFileOption = new FileOption("arffFile", 'f',
       "ARFF File(s) to load.", null, null, false);
 
-  public IntOption classIndexOption = new IntOption("classIndex", 'c',
+  /*public IntOption classIndexOption = new IntOption("classIndex", 'c',
       "Class index of data. 0 for none or -1 for last attribute in file.",
-      -1, -1, Integer.MAX_VALUE);
+      -1, -1, Integer.MAX_VALUE);*/
 
   protected InstanceExample lastInstanceRead;
   private BufferedReader fileReader;

--- a/samoa-api/src/main/java/org/apache/samoa/streams/AvroFileStream.java
+++ b/samoa-api/src/main/java/org/apache/samoa/streams/AvroFileStream.java
@@ -54,7 +54,7 @@ public class AvroFileStream extends FileStream {
   protected InstanceExample lastInstanceRead;
 
   /** Represents the binary input stream of avro data **/
-  protected transient InputStream inputStream = null;
+  //protected transient InputStream inputStream = null;
 
   /** The extension to be considered for the files **/
   private static final String AVRO_FILE_EXTENSION = "avro";
@@ -87,6 +87,7 @@ public class AvroFileStream extends FileStream {
    * 
    * @return
    */
+  @Override
   protected boolean getNextFileStream() {
     if (this.inputStream != null)
       try {
@@ -97,8 +98,7 @@ public class AvroFileStream extends FileStream {
       }
 
     this.inputStream = this.fileSource.getNextInputStream();
-
-    if (this.inputStream == null)
+    if (inputStream == null)
       return false;
 
     this.instances = new Instances(this.inputStream, classIndexOption.getValue(), encodingFormatOption.getValue());

--- a/samoa-api/src/main/java/org/apache/samoa/streams/AvroFileStream.java
+++ b/samoa-api/src/main/java/org/apache/samoa/streams/AvroFileStream.java
@@ -139,7 +139,8 @@ public class AvroFileStream extends FileStream {
   public void prepareForUseImpl(TaskMonitor monitor, ObjectRepository repository) {
     super.prepareForUseImpl(monitor, repository);
     String filePath = this.avroFileOption.getFile().getAbsolutePath();
-    this.fileSource.init(filePath, AvroFileStream.AVRO_FILE_EXTENSION);
+    //this.fileSource.init(filePath, AvroFileStream.AVRO_FILE_EXTENSION);
+    this.fileSource.init(filePath, null);
     this.lastInstanceRead = null;
   }
 

--- a/samoa-api/src/main/java/org/apache/samoa/streams/AvroFileStream.java
+++ b/samoa-api/src/main/java/org/apache/samoa/streams/AvroFileStream.java
@@ -45,8 +45,8 @@ public class AvroFileStream extends FileStream {
   private static final Logger logger = LoggerFactory.getLogger(AvroFileStream.class);
 
   public FileOption avroFileOption = new FileOption("avroFile", 'f', "Avro File(s) to load.", null, null, false);
-  public IntOption classIndexOption = new IntOption("classIndex", 'c',
-      "Class index of data. 0 for none or -1 for last attribute in file.", -1, -1, Integer.MAX_VALUE);
+  /*public IntOption classIndexOption = new IntOption("classIndex", 'c',
+      "Class index of data. 0 for none or -1 for last attribute in file.", -1, -1, Integer.MAX_VALUE);*/
   public StringOption encodingFormatOption = new StringOption("encodingFormatOption", 'e',
       "Encoding format for Avro Files. Can be JSON/AVRO", "BINARY");
 

--- a/samoa-api/src/main/java/org/apache/samoa/streams/FileStream.java
+++ b/samoa-api/src/main/java/org/apache/samoa/streams/FileStream.java
@@ -80,7 +80,16 @@ public abstract class FileStream extends AbstractOptionHandler implements Instan
 
   @Override
   public boolean hasMoreInstances() {
-    return !this.hitEndOfStream;
+    if (this.hitEndOfStream) {
+      if (getNextFileReader()) {
+        this.hitEndOfStream = false;
+        return hasMoreInstances();
+      } else {
+        return false;
+      }
+    } else {
+      return true;
+    }
   }
 
   @Override

--- a/samoa-api/src/main/java/org/apache/samoa/streams/FileStream.java
+++ b/samoa-api/src/main/java/org/apache/samoa/streams/FileStream.java
@@ -20,7 +20,10 @@ package org.apache.samoa.streams;
  * #L%
  */
 
-import com.github.javacliparser.*;
+import com.github.javacliparser.ClassOption;
+import com.github.javacliparser.FloatOption;
+import com.github.javacliparser.IntOption;
+import com.github.javacliparser.ListOption;
 import org.apache.samoa.instances.Instances;
 import org.apache.samoa.instances.InstancesHeader;
 import org.apache.samoa.moa.core.InstanceExample;
@@ -107,7 +110,7 @@ public abstract class FileStream extends AbstractOptionHandler implements Instan
     if (classWeights != null && classWeights.length > 0) {
       int i = (int) prevInstance.instance.classValue();
       double w = 1.0;
-      if (i>=0 && i<classWeights.length)
+      if (i >= 0 && i < classWeights.length)
         w = classWeights[i].getValue();
       prevInstance.setWeight(w);
     }

--- a/samoa-api/src/main/java/org/apache/samoa/streams/FileStream.java
+++ b/samoa-api/src/main/java/org/apache/samoa/streams/FileStream.java
@@ -31,6 +31,7 @@ import org.apache.samoa.streams.fs.FileStreamSource;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
 
 /**
  * InstanceStream for files (Abstract class: subclass this class for different file formats)
@@ -58,7 +59,7 @@ public abstract class FileStream extends AbstractOptionHandler implements Instan
   //protected transient Reader fileReader;
   protected transient InputStream inputStream;
   protected Instances instances;
-  protected FloatOption[] classWeights;
+  protected FloatOption[] classWeights; // = new FloatOption[0];
 
   protected boolean hitEndOfStream;
   private boolean hasStarted;
@@ -169,7 +170,7 @@ public abstract class FileStream extends AbstractOptionHandler implements Instan
   @Override
   public void prepareForUseImpl(TaskMonitor monitor, ObjectRepository repository) {
     this.fileSource = sourceTypeOption.getValue();
-    this.classWeights = (FloatOption[]) classWeightsOption.getList();
+    this.classWeights = Arrays.copyOf(classWeightsOption.getList(), classWeightsOption.getList().length, FloatOption[].class);
     this.hasStarted = false;
   }
 

--- a/samoa-api/src/main/resources/META-INF/services/org.apache.hadoop.fs.FileSystem
+++ b/samoa-api/src/main/resources/META-INF/services/org.apache.hadoop.fs.FileSystem
@@ -1,0 +1,2 @@
+org.apache.hadoop.fs.LocalFileSystem
+org.apache.hadoop.hdfs.DistributedFileSystem

--- a/samoa-instances/src/main/java/org/apache/samoa/instances/AvroLoader.java
+++ b/samoa-instances/src/main/java/org/apache/samoa/instances/AvroLoader.java
@@ -254,13 +254,28 @@ public abstract class AvroLoader implements Loader {
         List<String> attributeLabels = attributeSchema.getEnumSymbols();
         attributes.add(new Attribute(field.name(), attributeLabels));
       }
-      else if (attributeSchema.getType() == Schema.Type.DOUBLE
-              || attributeSchema.getType() == Schema.Type.FLOAT
-              || attributeSchema.getType() == Schema.Type.LONG
-              || attributeSchema.getType() == Schema.Type.INT)
+      else if (isNumeric(field))
         attributes.add(new Attribute(field.name()));
     }
     return new InstanceInformation(relation, attributes);
+  }
+
+  private boolean isNumeric(Field field) {
+    if (field.schema().getType() == Schema.Type.DOUBLE
+            || field.schema().getType() == Schema.Type.FLOAT
+            || field.schema().getType() == Schema.Type.LONG
+            || field.schema().getType() == Schema.Type.INT)
+      return true;
+    if (field.schema().getType() == Schema.Type.UNION) {
+      for (Schema schema: field.schema().getTypes()) {
+        if (schema.getType() == Schema.Type.DOUBLE
+                || schema.getType() == Schema.Type.FLOAT
+                || schema.getType() == Schema.Type.LONG
+                || schema.getType() == Schema.Type.INT)
+          return true;
+      }
+    }
+    return false;
   }
 
   /**

--- a/samoa-instances/src/main/java/org/apache/samoa/instances/AvroLoader.java
+++ b/samoa-instances/src/main/java/org/apache/samoa/instances/AvroLoader.java
@@ -26,6 +26,7 @@ import java.util.List;
 
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Field;
+import org.apache.avro.SchemaBuilder;
 import org.apache.avro.generic.GenericData.EnumSymbol;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.DatumReader;
@@ -164,8 +165,10 @@ public abstract class AvroLoader implements Loader {
 
       if (isNumeric)
       {
-        if (value instanceof Double)
-          this.setSparseValue(instance, indexValues, attributeValues, numAttribute, (double) value);
+        if (value instanceof Double) {
+          Double v = (double) value;
+          if (Double.isFinite(v)) this.setSparseValue(instance, indexValues, attributeValues, numAttribute, (double) value);
+        }
         else if (value instanceof Long)
           this.setSparseValue(instance, indexValues, attributeValues, numAttribute, (long) value);
         else if (value instanceof Integer)

--- a/samoa-instances/src/main/java/org/apache/samoa/instances/AvroLoader.java
+++ b/samoa-instances/src/main/java/org/apache/samoa/instances/AvroLoader.java
@@ -167,7 +167,9 @@ public abstract class AvroLoader implements Loader {
       {
         if (value instanceof Double) {
           Double v = (double) value;
-          if (Double.isFinite(v)) this.setSparseValue(instance, indexValues, attributeValues, numAttribute, (double) value);
+          //if (Double.isFinite(v))
+          if (!Double.isNaN(v) && !Double.isInfinite(v))
+            this.setSparseValue(instance, indexValues, attributeValues, numAttribute, (double) value);
         }
         else if (value instanceof Long)
           this.setSparseValue(instance, indexValues, attributeValues, numAttribute, (long) value);

--- a/samoa-instances/src/main/java/org/apache/samoa/instances/AvroLoader.java
+++ b/samoa-instances/src/main/java/org/apache/samoa/instances/AvroLoader.java
@@ -254,7 +254,10 @@ public abstract class AvroLoader implements Loader {
         List<String> attributeLabels = attributeSchema.getEnumSymbols();
         attributes.add(new Attribute(field.name(), attributeLabels));
       }
-      else
+      else if (attributeSchema.getType() == Schema.Type.DOUBLE
+              || attributeSchema.getType() == Schema.Type.FLOAT
+              || attributeSchema.getType() == Schema.Type.LONG
+              || attributeSchema.getType() == Schema.Type.INT)
         attributes.add(new Attribute(field.name()));
     }
     return new InstanceInformation(relation, attributes);

--- a/samoa-samza/pom.xml
+++ b/samoa-samza/pom.xml
@@ -62,12 +62,6 @@
       <version>${samza.version}</version>
     </dependency>
 
-    <dependency>
-      <groupId>org.apache.samza</groupId>
-      <artifactId>samza-serializers_2.10</artifactId>
-      <version>${samza.version}</version>
-    </dependency>
-
     <!--<dependency> <groupId>org.apache.samza</groupId> <artifactId>samza-shell</artifactId> <classifier>dist</classifier> 
       <type>tgz</type> <version>${samza.version}</version> </dependency> -->
 

--- a/samoa-samza/pom.xml
+++ b/samoa-samza/pom.xml
@@ -62,6 +62,12 @@
       <version>${samza.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.apache.samza</groupId>
+      <artifactId>samza-serializers_2.10</artifactId>
+      <version>${samza.version}</version>
+    </dependency>
+
     <!--<dependency> <groupId>org.apache.samza</groupId> <artifactId>samza-shell</artifactId> <classifier>dist</classifier> 
       <type>tgz</type> <version>${samza.version}</version> </dependency> -->
 

--- a/samoa-samza/src/main/java/org/apache/samoa/utils/SystemsUtils.java
+++ b/samoa-samza/src/main/java/org/apache/samoa/utils/SystemsUtils.java
@@ -96,6 +96,20 @@ public class SystemsUtils {
     private static String hdfsConfPath;
     private static String configHomePath;
     private static String samoaDir = null;
+    
+    private static Configuration getConfig() {
+      Configuration config = new Configuration();
+      config.addResource(new Path(coreConfPath));
+      config.addResource(new Path(hdfsConfPath));
+      /* will do same differently - see http://www.lucidelectricdreams.com/2013/11/no-filesystem-for-scheme-hdfs.html
+      config.set("fs.hdfs.impl",
+              org.apache.hadoop.hdfs.DistributedFileSystem.class.getName()
+      );
+      config.set("fs.file.impl",
+              org.apache.hadoop.fs.LocalFileSystem.class.getName()
+      ); */
+      return config;
+    }
 
     static void setHadoopConfigHome(String hadoopConfPath) {
       logger.info("Hadoop config home:{}", hadoopConfPath);


### PR DESCRIPTION
FileStreamSource seemed to support multiple files but during my testing it turned out otherwise - Samoa AvroFileStream from HDFSFileStreamSource stops at end of first file. I had to change AvroFileStream, ArffFileStream and their parent FileStream in order to make this work.

See following JIRA for additional detail:

https://issues.apache.org/jira/browse/SAMOA-58

Additionally, I modified bin/samoa, pom.xml, SystemUtils (as well as added a resource) to fix reading from HDFS on my cluster.

A seemingly unrelated change is the explicit test for supported Avro types so as to filter out any fields that are not supported instead of assuming all non-nominal (non-enum) fields are numeric and failing during reading.