### PR TITLE
Fix bug in DenseInstance toString method and in TextGenerator class

### DIFF
--- a/samoa-api/src/main/java/org/apache/samoa/streams/TextGenerator.java
+++ b/samoa-api/src/main/java/org/apache/samoa/streams/TextGenerator.java
@@ -109,7 +109,7 @@ public class TextGenerator extends AbstractOptionHandler implements InstanceStre
             }
         } while (votes[1] == votes[2]);
 
-        Instance inst = new DenseInstance(1.0, attVals);
+        Instance inst = new SparseInstance(1.0, attVals);
         inst.setDataset(getHeader());
         inst.setClassValue((votes[1] > votes[2]) ? 0 : 1);
         this.countTweets++;

--- a/samoa-instances/src/main/java/org/apache/samoa/instances/Attribute.java
+++ b/samoa-instances/src/main/java/org/apache/samoa/instances/Attribute.java
@@ -26,10 +26,7 @@ package org.apache.samoa.instances;
 
 import java.io.Serializable;
 import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * @author abifet
@@ -37,9 +34,9 @@ import java.util.Map;
 public class Attribute implements Serializable {
 
   public static final String ARFF_ATTRIBUTE = "@attribute";
-  public static final String ARFF_ATTRIBUTE_NUMERIC = "NUMERIC";
-  public static final String ARFF_ATTRIBUTE_NOMINAL = "NOMINAL";
-  public static final String ARFF_ATTRIBUTE_DATE = "DATE";
+  public static final String ARFF_ATTRIBUTE_NUMERIC = "numeric";
+  public static final String ARFF_ATTRIBUTE_NOMINAL = "nominal";
+  public static final String ARFF_ATTRIBUTE_DATE = "date";
 
   /**
    *
@@ -199,7 +196,14 @@ public class Attribute implements Serializable {
     text.append(ARFF_ATTRIBUTE).append(" ").append(Utils.quote(this.name)).append(" ");
 
     if (isNominal) {
-      text.append(ARFF_ATTRIBUTE_NOMINAL);
+      text.append('{');
+      Enumeration enu =  enumerateValues();
+      while (enu.hasMoreElements()) {
+        text.append(Utils.quote((String) enu.nextElement()));
+        if (enu.hasMoreElements())
+          text.append(',');
+      }
+      text.append('}');
     } else if (isNumeric) {
       text.append(ARFF_ATTRIBUTE_NUMERIC);
     } else if (isDate) {
@@ -207,5 +211,19 @@ public class Attribute implements Serializable {
     }
 
     return text.toString();
+  }
+
+  /**
+   * Returns an enumeration of all the attribute's values if the
+   * attribute is nominal, null otherwise.
+   *
+   * @return enumeration of all the attribute's values
+   */
+  public final /*@ pure @*/ Enumeration enumerateValues() {
+
+    if (this.isNominal()) {
+      return Collections.enumeration(this.attributeValues);
+    }
+    return null;
   }
 }

--- a/samoa-instances/src/main/java/org/apache/samoa/instances/DenseInstance.java
+++ b/samoa-instances/src/main/java/org/apache/samoa/instances/DenseInstance.java
@@ -24,6 +24,8 @@ package org.apache.samoa.instances;
  * #L%
  */
 
+import java.text.SimpleDateFormat;
+
 /**
  * @author abifet
  */
@@ -61,13 +63,25 @@ public class DenseInstance extends SingleLabelInstance {
   public String toString() {
     StringBuffer text = new StringBuffer();
 
-    for (int i = 0; i < this.instanceData.numAttributes(); i++) {
-      if (i > 0) {
-        text.append(",");
+    //append all attributes except the class attribute.
+    for (int attIndex = 0; attIndex < this.numAttributes()-1; attIndex++) {
+      if (!this.isMissing(attIndex)) {
+        if (this.attribute(attIndex).isNominal()) {
+          int valueIndex = (int) this.value(attIndex);
+          String stringValue = this.attribute(attIndex).value(valueIndex);
+          text.append(stringValue).append(",");
+        } else if (this.attribute(attIndex).isNumeric()) {
+          text.append(this.value(attIndex)).append(",");
+        } else if (this.attribute(attIndex).isDate()) {
+          SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+          text.append(dateFormatter.format(this.value(attIndex))).append(",");
+        }
+      } else {
+        text.append("?,");
       }
-      text.append(this.value(i));
     }
-    text.append(",").append(this.weight());
+    //append the class value at the end of the instance.
+    text.append(this.classAttribute().value((int)classValue()));
 
     return text.toString();
   }

--- a/samoa-instances/src/main/java/org/apache/samoa/instances/SingleLabelInstance.java
+++ b/samoa-instances/src/main/java/org/apache/samoa/instances/SingleLabelInstance.java
@@ -212,13 +212,13 @@ public class SingleLabelInstance implements Instance {
 
   @Override
   public Attribute classAttribute() {
-    return this.instanceInformation.attribute(0);
+    //return the class attribute
+    return this.instanceInformation.attribute(classIndex());
   }
 
   @Override
   public void setClassValue(double d) {
     this.classData.setValue(0, d);
-    // this.classValue = d;
   }
 
   @Override

--- a/samoa-instances/src/main/java/org/apache/samoa/instances/SparseInstance.java
+++ b/samoa-instances/src/main/java/org/apache/samoa/instances/SparseInstance.java
@@ -24,6 +24,8 @@ package org.apache.samoa.instances;
  * #L%
  */
 
+import java.text.SimpleDateFormat;
+
 /**
  * 
  * @author abifet
@@ -47,4 +49,38 @@ public class SparseInstance extends SingleLabelInstance {
     super(weight, attributeValues, indexValues, numberAttributes);
   }
 
+  @Override
+  public String toString() {
+    StringBuffer str = new StringBuffer();
+
+    str.append("{");
+
+    for (int i=0; i<this.numAttributes()-1;i++){
+      if (!this.isMissing(i)) {
+
+        //if the attribute is Nominal we print the string value of the attribute.
+        if (this.attribute(i).isNominal()) {
+          int valueIndex = (int) this.value(i);
+          String stringValue = this.attribute(i).value(valueIndex);
+          str.append(i).append(" ").append(stringValue).append(",");
+        } else if (this.attribute(i).isNumeric()) {
+          //if the attribute is numeric we print the value of the attribute only if it is not equal 0
+          if (this.value(i) != 0) {
+            str.append(i).append(" ").append(this.value(i)).append(",");
+          }
+        } else if (this.attribute(i).isDate()) {
+          SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+          str.append(i).append(" ").append(dateFormatter.format(this.value(i))).append(",");
+        }
+      } else { //represent missing values
+        str.append(i).append(" ").append("?,");
+      }
+    }
+    //append the class value at the end of the instance.
+    str.append(classIndex()).append(" ").append(this.classAttribute().value((int)classValue()));
+
+    str.append("}");
+
+    return str.toString();
+  }
 }


### PR DESCRIPTION
- Fixed bug in DenseInstance class toString method which resulted in always writing an arff file with class equal to zero.

- Change TextGenerator class to create SparseInstances instead of  DenseInstances.

- Change the Attribute class in order to write the values of the nominal attributes between brackets in the attribute section of the arff file.

- Change SingleLabelInstance classAttribute method in to return the correct attribute that represents the class value.

- Override toString in SparseInstance class in order to write sparse formatted arff files.

