### PR TITLE
SAMOA-71: fixes concurrency issues in HorizontalAMRulesRegressor

### DIFF
--- a/bin/samoa-storm.properties
+++ b/bin/samoa-storm.properties
@@ -34,4 +34,4 @@ samoa.storm.mode=local
 samoa.storm.numworker=4
 
 # samoa.storm.local.mode.execution.duration corresponds to the execution duration of the local topology  in seconds. 
-samoa.storm.local.mode.execution.duration=200
+samoa.storm.local.mode.execution.duration=400

--- a/samoa-api/src/main/java/org/apache/samoa/learners/classifiers/rules/distributed/AMRRuleSetProcessor.java
+++ b/samoa-api/src/main/java/org/apache/samoa/learners/classifiers/rules/distributed/AMRRuleSetProcessor.java
@@ -20,8 +20,7 @@ package org.apache.samoa.learners.classifiers.rules.distributed;
  * #L%
  */
 
-import java.util.LinkedList;
-import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.apache.samoa.core.ContentEvent;
 import org.apache.samoa.core.Processor;
@@ -56,7 +55,7 @@ public class AMRRuleSetProcessor implements Processor {
   private int processorId;
 
   // Rules & default rule
-  protected transient List<PassiveRule> ruleSet;
+  protected transient CopyOnWriteArrayList<PassiveRule> ruleSet;
 
   // SAMOA Stream
   private Stream statisticsStream;
@@ -251,7 +250,7 @@ public class AMRRuleSetProcessor implements Processor {
   @Override
   public void onCreate(int id) {
     this.processorId = id;
-    this.ruleSet = new LinkedList<PassiveRule>();
+    this.ruleSet = new CopyOnWriteArrayList<PassiveRule>();
 
   }
 

--- a/samoa-storm/src/test/java/org/apache/samoa/AlgosTest.java
+++ b/samoa-storm/src/test/java/org/apache/samoa/AlgosTest.java
@@ -68,7 +68,7 @@ public class AlgosTest {
 
   }
 
-  @Test(timeout = 120000)
+  @Test(timeout = 240000)
   public void testCVPReqVHTWithStorm() throws Exception {
 
     TestParams vhtConfig = new TestParams.Builder()


### PR DESCRIPTION
I suggest a change in ruleSet implementation from LinkedList (providing fail-fast iterators, which causes ConcurrencyException when list content changes during iterating over it) to CopyOnWriteArrayList (which is a thread-safe variant eliminating concurrency exceptions). In the analysed case, the modifications to ruleSet are expected to be much less frequent than reading the rules. When the number of read operations is relatively large and update operations are far less frequent, a possible choice is CopyOnWriteArrayList.

I have compared the performance on 35k instance streams (with a higher than 35k number concurrency exception got thrown) and got the same <1 second processing time. Hence, the possible negative impact on the performance can be considered negligible, if any. Still, suggestions and possible other solution ideas from designers of AMRules are welcome.