### PR TITLE
SAMOA-30 change samoa-storm properties file path

### DIFF
--- a/samoa-storm/src/main/java/org/apache/samoa/topology/impl/StormJarSubmitter.java
+++ b/samoa-storm/src/main/java/org/apache/samoa/topology/impl/StormJarSubmitter.java
@@ -66,7 +66,7 @@ public class StormJarSubmitter {
     Properties props = StormSamoaUtils.getProperties();
     props.setProperty(StormJarSubmitter.UPLOADED_JAR_LOCATION_KEY, uploadedJarLocation);
 
-    File f = new File("src/main/resources/samoa-storm-cluster.properties");
+    File f = new File("../bin/samoa-storm.properties");
     f.createNewFile();
 
     OutputStream out = new FileOutputStream(f);

--- a/samoa-storm/src/main/java/org/apache/samoa/topology/impl/StormSamoaUtils.java
+++ b/samoa-storm/src/main/java/org/apache/samoa/topology/impl/StormSamoaUtils.java
@@ -52,18 +52,20 @@ public class StormSamoaUtils {
 
   static Properties getProperties() throws IOException {
     Properties props = new Properties();
-    InputStream is;
+    InputStream is = null;
 
-    File f = new File("src/main/resources/samoa-storm-cluster.properties"); // FIXME it does not exist anymore
-    is = new FileInputStream(f);
+    File f = new File("../bin/samoa-storm.properties");
 
     try {
+      is = new FileInputStream(f);
       props.load(is);
     } catch (IOException e1) {
-      System.out.println("Fail to load property file");
+      System.out.println("Fail to load samoa-storm property file");
       return null;
     } finally {
-      is.close();
+      if (is != null) {
+        is.close();
+      }
     }
 
     return props;


### PR DESCRIPTION
I update wrong properties file path for samoa-storm setting, and put FileInputStream inside try-catch statement to avoid exception crash.
Please look on whether it is correct or not. Thanks.