### PR TITLE
SAMOA-73: fixes NullPointerException in VerticalHoeffdingTree

### DIFF
--- a/samoa-api/src/main/java/org/apache/samoa/learners/classifiers/trees/FoundNode.java
+++ b/samoa-api/src/main/java/org/apache/samoa/learners/classifiers/trees/FoundNode.java
@@ -34,7 +34,7 @@ final class FoundNode implements java.io.Serializable {
 	 */
   private static final long serialVersionUID = -637695387934143293L;
 
-  private final Node node;
+  private Node node;
   private final SplitNode parent;
   private final int parentBranch;
 
@@ -52,6 +52,17 @@ final class FoundNode implements java.io.Serializable {
    */
   Node getNode() {
     return this.node;
+  }
+
+  /**
+   * Method to set the node where an instance is routed/filtered through the decision tree model for testing and
+   * training. The method is expected to be used when the original FoundNode object had null node property.
+   * This is to add a reference to a newly established node object.
+   * 
+   * @param node  the node reference to be inserted
+   */
+  void setNode(Node node) {
+    this.node = node;
   }
 
   /**

--- a/samoa-api/src/main/java/org/apache/samoa/learners/classifiers/trees/ModelAggregatorProcessor.java
+++ b/samoa-api/src/main/java/org/apache/samoa/learners/classifiers/trees/ModelAggregatorProcessor.java
@@ -417,6 +417,7 @@ final class ModelAggregatorProcessor implements Processor {
 
     if (leafNode == null) {
       leafNode = newLearningNode(this.parallelismHint);
+      foundNode.setNode(leafNode);
       foundNode.getParent().setChild(foundNode.getParentBranch(), leafNode);
       activeLeafNodeCount++;
     }


### PR DESCRIPTION
java.lang.NullPointerException is in some cases thrown in  org.apache.samoa.learners.classifiers.trees.ModelAggregatorProcessor.process(ModelAggregatorProcessor.java:142)
The problem occurs because FoundNode objects in some cases contain null node property.  Such FoundNode objects can be created and are considered valid, which directly follows from filterInstanceToLeaf(Instance inst, SplitNode parent, int parentBranch)  method of SplitNode class.
However, once a categorical feature is selected for the splits, the following situation can happen:
1)  first FoundNode object with null node object inside is created
2)  Next, the tree structure is grown by establishing new LearningNode, which is done in ModelAggregatorProcessor.java/trainOnInstanceImpl(FoundNode foundNode, Instance inst) 
3) The problem is the LearningNode is not added to FoundNode helper object already existing at this stage, which causes NullPointerException exception when trying to use it.

Solution: In such cases, the FoundNode object should reflect the newly created tree extension. This can be done by injecting into the FoundNode the newly created Node object. This is to keep FoundNode in sync with the most recent tree structure. This is what this fix makes: it replaces null node object with the newly created one.
