### PR TITLE
SAMOA-76: changes JDK used for Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ branches:
     - gh-pages
 
 jdk:
-- oraclejdk7
+- openjdk7
 
 install:
 - echo "<settings><servers><server><id>apache.snapshots.https</id><username>${SOSS_USERNAME}</username><password>${SOSS_PASSWORD}</password></server></servers></settings>" > ${HOME}/.m2/settings.xml


### PR DESCRIPTION
SAMOA-76: changes JDK used for Travis builds