### PR TITLE
SAMOA-78: Accept newly arriving values of nominal attributes

### DIFF
--- a/samoa-instances/src/main/java/org/apache/samoa/instances/Attribute.java
+++ b/samoa-instances/src/main/java/org/apache/samoa/instances/Attribute.java
@@ -243,8 +243,14 @@ public class Attribute implements Serializable {
       }
     }
     Integer val = (Integer) this.valuesStringAttribute.get(value);
+    
+    // in case this value was not on a list of unique values of nominal attribute yet, add it
+    // this means, the list of values can be extended with new entries arriving in the stream
     if (val == null) {
-      return -1;
+      int currentValueCount=this.valuesStringAttribute.size();
+      this.valuesStringAttribute.put(value,currentValueCount);
+      this.attributeValues.add(value);
+      return currentValueCount;
     } else {
       return val.intValue();
     }


### PR DESCRIPTION
This extension makes Attribute accept new values of nominal attributes arriving in the stream. Hence, there is no need for preprocessing of the stream to discover all values of nominal attributes first to put them e.g. in ARFF header next. 