### PR TITLE
Flink-Adapter: fix reflection errors

### DIFF
--- a/samoa-api/src/main/java/org/apache/samoa/learners/classifiers/trees/AttributeBatchContentEvent.java
+++ b/samoa-api/src/main/java/org/apache/samoa/learners/classifiers/trees/AttributeBatchContentEvent.java
@@ -31,7 +31,7 @@ import org.apache.samoa.core.ContentEvent;
  * @author Arinto Murdopo
  * 
  */
-final class AttributeBatchContentEvent implements ContentEvent {
+public final class AttributeBatchContentEvent implements ContentEvent {
 
   private static final long serialVersionUID = 6652815649846676832L;
 
@@ -49,7 +49,7 @@ final class AttributeBatchContentEvent implements ContentEvent {
     isNominal = true;
   }
 
-  private AttributeBatchContentEvent(Builder builder) {
+  public AttributeBatchContentEvent(Builder builder) {
     this.learningNodeId = builder.learningNodeId;
     this.obsIndex = builder.obsIndex;
     this.contentEventList = new LinkedList<>();
@@ -96,7 +96,7 @@ final class AttributeBatchContentEvent implements ContentEvent {
     return this.isNominal;
   }
 
-  static final class Builder {
+  public static final class Builder {
 
     // required parameters
     private final long learningNodeId;

--- a/samoa-api/src/main/java/org/apache/samoa/learners/classifiers/trees/ControlContentEvent.java
+++ b/samoa-api/src/main/java/org/apache/samoa/learners/classifiers/trees/ControlContentEvent.java
@@ -28,7 +28,7 @@ import org.apache.samoa.core.ContentEvent;
  * @author Arinto Murdopo
  * 
  */
-abstract class ControlContentEvent implements ContentEvent {
+public abstract class ControlContentEvent implements ContentEvent {
 
   /**
 	 * 

--- a/samoa-api/src/main/java/org/apache/samoa/learners/classifiers/trees/DeleteContentEvent.java
+++ b/samoa-api/src/main/java/org/apache/samoa/learners/classifiers/trees/DeleteContentEvent.java
@@ -27,7 +27,7 @@ package org.apache.samoa.learners.classifiers.trees;
  * @author Arinto Murdopo
  * 
  */
-final class DeleteContentEvent extends ControlContentEvent {
+public final class DeleteContentEvent extends ControlContentEvent {
 
   private static final long serialVersionUID = -2105250722560863633L;
 

--- a/samoa-api/src/main/java/org/apache/samoa/learners/classifiers/trees/FilterProcessor.java
+++ b/samoa-api/src/main/java/org/apache/samoa/learners/classifiers/trees/FilterProcessor.java
@@ -41,7 +41,7 @@ import java.util.List;
  * @author Arinto Murdopo
  * 
  */
-final class FilterProcessor implements Processor {
+public final class FilterProcessor implements Processor {
 
   private static final long serialVersionUID = -1685875718300564885L;
   private static final Logger logger = LoggerFactory.getLogger(FilterProcessor.class);

--- a/samoa-api/src/main/java/org/apache/samoa/learners/classifiers/trees/FoundNode.java
+++ b/samoa-api/src/main/java/org/apache/samoa/learners/classifiers/trees/FoundNode.java
@@ -27,7 +27,7 @@ package org.apache.samoa.learners.classifiers.trees;
  * @author Arinto Murdopo
  * 
  */
-final class FoundNode implements java.io.Serializable {
+public final class FoundNode implements java.io.Serializable {
 
   /**
 	 * 

--- a/samoa-api/src/main/java/org/apache/samoa/learners/classifiers/trees/InactiveLearningNode.java
+++ b/samoa-api/src/main/java/org/apache/samoa/learners/classifiers/trees/InactiveLearningNode.java
@@ -29,7 +29,7 @@ import org.apache.samoa.instances.Instance;
  * @author Arinto Murdopo
  * 
  */
-final class InactiveLearningNode extends LearningNode {
+public final class InactiveLearningNode extends LearningNode {
 
   /**
 	 * 

--- a/samoa-api/src/main/java/org/apache/samoa/learners/classifiers/trees/LearningNode.java
+++ b/samoa-api/src/main/java/org/apache/samoa/learners/classifiers/trees/LearningNode.java
@@ -28,7 +28,7 @@ import org.apache.samoa.instances.Instance;
  * @author Arinto Murdopo
  * 
  */
-abstract class LearningNode extends Node {
+public abstract class LearningNode extends Node {
 
   private static final long serialVersionUID = 7157319356146764960L;
 

--- a/samoa-api/src/main/java/org/apache/samoa/learners/classifiers/trees/LocalResultContentEvent.java
+++ b/samoa-api/src/main/java/org/apache/samoa/learners/classifiers/trees/LocalResultContentEvent.java
@@ -30,7 +30,7 @@ import org.apache.samoa.moa.classifiers.core.AttributeSplitSuggestion;
  * @author Arinto Murdopo
  * 
  */
-final class LocalResultContentEvent implements ContentEvent {
+public final class LocalResultContentEvent implements ContentEvent {
 
   private static final long serialVersionUID = -4206620993777418571L;
 

--- a/samoa-api/src/main/java/org/apache/samoa/learners/classifiers/trees/LocalStatisticsProcessor.java
+++ b/samoa-api/src/main/java/org/apache/samoa/learners/classifiers/trees/LocalStatisticsProcessor.java
@@ -47,7 +47,7 @@ import com.google.common.collect.Table;
  * @author Arinto Murdopo
  * 
  */
-final class LocalStatisticsProcessor implements Processor {
+public final class LocalStatisticsProcessor implements Processor {
 
   /**
 	 * 

--- a/samoa-api/src/main/java/org/apache/samoa/learners/classifiers/trees/ModelAggregatorProcessor.java
+++ b/samoa-api/src/main/java/org/apache/samoa/learners/classifiers/trees/ModelAggregatorProcessor.java
@@ -64,7 +64,7 @@ import org.slf4j.LoggerFactory;
  * @author Arinto Murdopo
  * 
  */
-final class ModelAggregatorProcessor implements Processor {
+public final class ModelAggregatorProcessor implements Processor {
 
   private static final long serialVersionUID = -1685875718300564886L;
   private static final Logger logger = LoggerFactory.getLogger(ModelAggregatorProcessor.class);


### PR DESCRIPTION
We were investigating on the issue that SAMOA didn't work with the current Flink version and had issues with the serialization because some of the classes of the classifiers were not set to public.

Therefore we propose to change the modifiers to public if there is no reason (we couldn't come up with one) that speaks against it.

Cheers